### PR TITLE
Added simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,7 @@
 .byebug_history
 .env
 
+/coverage/*
+
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/Gemfile
+++ b/Gemfile
@@ -81,4 +81,5 @@ end
 group :test do
   gem 'minitest-rails'
   gem 'minitest-reporters'
+  gem 'simplecov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,6 @@ GEM
       autoprefixer-rails (>= 6.0.3)
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)
-    bootstrap-toggle-rails (2.2.1.0)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (3.9.0)
@@ -82,6 +81,7 @@ GEM
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     debug_inspector (0.0.3)
+    docile (1.3.1)
     dotenv (2.5.0)
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
@@ -123,6 +123,7 @@ GEM
     jquery-turbolinks (2.1.0)
       railties (>= 3.1.0)
       turbolinks
+    json (2.1.0)
     jwt (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -233,6 +234,11 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
     shellany (0.0.1)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -274,7 +280,6 @@ DEPENDENCIES
   binding_of_caller
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.1.3)
-  bootstrap-toggle-rails
   byebug
   capybara (>= 2.15)
   chromedriver-helper
@@ -296,6 +301,7 @@ DEPENDENCIES
   rails (~> 5.2.1)
   sass-rails (~> 5.0)
   selenium-webdriver
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,9 @@ require File.expand_path("../../config/environment", __FILE__)
 require "rails/test_help"
 require "minitest/rails"
 require "minitest/reporters"  # for Colorized output
-#  For colorful output!
+require 'simplecov'
+SimpleCov.start
+
 Minitest::Reporters.use!(
   Minitest::Reporters::SpecReporter.new,
   ENV,


### PR DESCRIPTION
Here is our first report (I only ran it for the models since we haven't done much controller testing yet):
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/35181875/47402526-fa0b1b00-d6fa-11e8-83c2-dbc6401e547a.png">

Now when you run tests, you should be able to open up the coverage report with **open coverage/index.html** --where index.html is the name of the latest simplecov file generated.